### PR TITLE
Add error diagnostic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ export function diagramPlugin(md: MarkdownIt, options: any) {
                     }, element);
                 } catch (e) {
                     console.log(`Error in running Mermaid.mermaidAPI.render: ${e}`);
+                    return `<div class="alert alert-warning">${e.str}</div>`;
                 } finally {
                     element.remove();
                 }


### PR DESCRIPTION
Don't require the user to load the javascript console in order to figure out what went wrong during parsing.